### PR TITLE
fix a bug that scheduler will assign two OSDID to an task

### DIFF
--- a/src/state/StateMachine.cpp
+++ b/src/state/StateMachine.cpp
@@ -171,6 +171,24 @@ void StateMachine::updateTaskToRunning(string taskId)
 
 }
 
+void StateMachine::updateTaskToWaitingOSDID(string taskId)
+{
+  auto it = taskMap.find(taskId);
+  if (it != taskMap.end()) {
+    LOG(INFO) << "Update the taskState to WAITING_OSDID for " << taskId;
+    TaskState& taskState = taskMap[taskId];
+    updateCounters(taskState.taskType,
+        taskState.currentStatus,
+        Status::WAITING_OSDID);
+    taskState.currentStatus = Status::WAITING_OSDID;
+    LOG(INFO) << "After update: ";
+    LOG(INFO) << taskState.toString();
+  } else {
+    LOG(ERROR) << "No value found in taskMap with key: " << taskId;
+  }
+
+}
+
 void StateMachine::updateTaskToStarting(string taskId)
 {
   auto it = taskMap.find(taskId);
@@ -186,7 +204,7 @@ void StateMachine::updateTaskToStarting(string taskId)
   } else {
     LOG(ERROR) << "No value found in taskMap with key: " << taskId;
   }
-
+ 
 }
 
 void StateMachine::updateTaskToFailed(string taskId)
@@ -280,7 +298,7 @@ vector<TaskState> StateMachine::getWaitingOSDTask()
   for ( auto it = taskMap.begin(); it != taskMap.end(); it++) {
     taskState = static_cast<TaskState>(it->second);
     if (taskState.taskType == TaskType::OSD
-        && taskState.currentStatus == Status::STARTING){
+        && taskState.currentStatus == Status::WAITING_OSDID){
       vc.push_back(taskState);
     }
   }

--- a/src/state/StateMachine.cpp
+++ b/src/state/StateMachine.cpp
@@ -204,7 +204,6 @@ void StateMachine::updateTaskToStarting(string taskId)
   } else {
     LOG(ERROR) << "No value found in taskMap with key: " << taskId;
   }
- 
 }
 
 void StateMachine::updateTaskToFailed(string taskId)

--- a/src/state/StateMachine.hpp
+++ b/src/state/StateMachine.hpp
@@ -52,6 +52,8 @@ public:
 
   void updateTaskToRunning(string taskId);
 
+  void updateTaskToWaitingOSDID(string taskId);
+
   void updateTaskToStarting(string taskId);
 
   void updateTaskToFailed(string taskId);

--- a/src/state/Status.hpp
+++ b/src/state/Status.hpp
@@ -24,6 +24,7 @@ namespace ceph{
 enum class Status : int
 {
   STAGING = 0,
+  WAITING_OSDID,
   STARTING,
   RUNNING,
   FAILED,

--- a/src/state/TaskState.hpp
+++ b/src/state/TaskState.hpp
@@ -64,6 +64,9 @@ public:
       case Status::STAGING:
         status = "STAGING";
         break;
+      case Status::WAITING_OSDID:
+        status = "WAITING_OSDID";
+        break;
       case Status::STARTING:
         status = "STARTING";
         break;


### PR DESCRIPTION
add a Status "WAITING_OSDID" to identify the task which already got an OSDID