### PR TITLE
Two networks and jnlparts in yml file

### DIFF
--- a/etc/cephmesos/cephmesos.d/slave01.yml
+++ b/etc/cephmesos/cephmesos.d/slave01.yml
@@ -1,5 +1,3 @@
-mgmtdev:   enp4s0f0
-datadev:   enp9s0
 osddevs:
   - sdc
   - sdd
@@ -9,3 +7,4 @@ osddevs:
 jnldevs:
   - sdb
   - sde
+jnlparts:   5

--- a/etc/cephmesos/cephmesos.yml
+++ b/etc/cephmesos/cephmesos.yml
@@ -5,11 +5,12 @@ zookeeper: zk://master.mesos:2181
 restport:  8889
 fileport:  8888
 fileroot:  ./
-mgmtdev:   eno1
-datadev:   enp8s0f0
+mgmtdev:   192.168.1.0/16
+datadev:   10.1.2.0/16
 osddevs:
   - sdb
   - sdc
   - sdd
   - sde
 jnldevs:   []
+jnlparts:  4

--- a/src/common/Config.cpp
+++ b/src/common/Config.cpp
@@ -36,6 +36,7 @@ DEFINE_string(master, "", "Mesos master uri");
 DEFINE_string(zookeeper, "", "Zookeeper uri");
 DEFINE_int32(restport, 0, "The REST API server port");
 DEFINE_int32(fileport, 0, "The static file server port");
+DEFINE_int32(jnlparts, 4, "The partition count of journal device");
 DEFINE_string(fileroot, "", "The static file server rootdir");
 
 Config* get_config(int* argc, char*** argv)
@@ -57,6 +58,7 @@ Config* get_config(int* argc, char*** argv)
       config->datadev,
       config->osddevs,
       config->jnldevs,
+      (FLAGS_jnlparts == 4 ? config->jnlparts : FLAGS_jnlparts)
   };
   if (cfg.id.empty() ||
     cfg.role.empty() ||
@@ -142,6 +144,7 @@ Config* parse_config_string(string input)
       (config["datadev"] ? config["datadev"].as<string>() : empty_s),
       (config["osddevs"] ? config["osddevs"].as<vector<string>>() : empty_v),
       (config["jnldevs"] ? config["jnldevs"].as<vector<string>>() : empty_v),
+      (config["jnlparts"] ? config["jnlparts"].as<int>() : FLAGS_jnlparts)
   };
   Config* cfg_p = new Config(cfg);
   return cfg_p;
@@ -161,6 +164,7 @@ Config* merge_config(Config* defaultConfig, Config* hostConfig)
       (hostConfig->datadev.empty() ? defaultConfig->datadev : hostConfig->datadev),
       (hostConfig->osddevs.empty() ? defaultConfig->osddevs : hostConfig->osddevs),
       (hostConfig->jnldevs.empty() ? defaultConfig->jnldevs : hostConfig->jnldevs),
+      (hostConfig->jnlparts == 4 ? defaultConfig->jnlparts : hostConfig->jnlparts),
   };
   Config* config_p = new Config(config);
   free(defaultConfig);

--- a/src/common/Config.hpp
+++ b/src/common/Config.hpp
@@ -37,6 +37,7 @@ struct Config
   std::string datadev;
   std::vector <std::string> osddevs;
   std::vector <std::string> jnldevs;
+  int jnlparts;
 };
 
 Config* get_config(int* argc, char*** argv);

--- a/src/common/StringUtil.hpp
+++ b/src/common/StringUtil.hpp
@@ -21,8 +21,10 @@
 
 #include <sstream>
 #include <vector>
+#include <boost/lexical_cast.hpp>
 
 using std::vector;
+using boost::lexical_cast;
 
 class StringUtil
 {
@@ -47,6 +49,20 @@ public:
         r.push_back(pc);
     }
     return r;
+  }
+  static bool matchIPToCIDR(string ip, string CIDR)
+  {
+    vector<string> ipTokens = explode(ip, '.');
+    vector<string> tmpTokens = explode(CIDR, '/');
+    string subnet = tmpTokens[0];
+    vector<string> subnetTokens = explode(subnet, '.');
+    int netmaskLength = lexical_cast<int>(tmpTokens[1]);
+    for (int i = 0; i < netmaskLength/8; i++) {
+      if (ipTokens[i] != subnetTokens[i]) {
+        return false;
+      }
+    }
+    return true;
   }
 };
 #endif

--- a/src/executor/CephExecutor.hpp
+++ b/src/executor/CephExecutor.hpp
@@ -60,7 +60,7 @@ private:
 
   bool createLocalSharedConfigDir(string localSharedConfigDir);
 
-  bool copySharedConfigFiles(string localSharedConfigDir);
+  bool copySharedConfigFiles();
 
   string getContainerName(string taskId);
 
@@ -90,6 +90,8 @@ private:
   bool prepareDisks();
 
   bool mountDisk(string diskname, string dir, string flags);
+
+  string getPublicNetworkIP(string ips, string CIDR);
 
   string containerName;
 

--- a/src/httpserver/FileServer.cpp
+++ b/src/httpserver/FileServer.cpp
@@ -101,5 +101,5 @@ int fileServer(const int port, const std::string & _path )
   if (!daemon) {
     return 1;
   }
-  while (1);
+  while (1){usleep(3*1000000);};
 }

--- a/src/httpserver/RestServer.cpp
+++ b/src/httpserver/RestServer.cpp
@@ -154,5 +154,5 @@ int restServer(int port = 8889)
   if (!server.check()) {
     return 1;
   }
-  while (1);
+  while (1){usleep(3*1000000);};
 }

--- a/src/scheduler/CephSchedulerAgent.hpp
+++ b/src/scheduler/CephSchedulerAgent.hpp
@@ -233,8 +233,7 @@ void CephSchedulerAgent<T>::statusUpdate(
           vector<string> devs = StringUtil::explode(failedDevs[1], ',');
         }
         HostConfig* hostconfig = stateMachine->getConfig(hostname);
-        //TODO: get this "4" from yml config
-        hostconfig->updateDiskPartition(devs,lexical_cast<int>("4"));
+        hostconfig->updateDiskPartition(devs,hostconfig->getJnlPartitionCount());
         hostconfig->setDiskPreparationDone();
       }
     }
@@ -661,10 +660,9 @@ void CephSchedulerAgent<T>::tryLaunchDiskTask(
     one_label->set_value((*pendingJNLDevs)[i]);
   }
   // jnl partition count
-  //TODO: get this jnl partition count from yml file
   Label* one_label = labels.add_labels();
   one_label->set_key(CustomData::jnlPartitionCountKey);
-  one_label->set_value("4");
+  one_label->set_value(lexical_cast<string>(hostconfig->getJnlPartitionCount()));
   task.mutable_labels()->MergeFrom(labels);
   //reousrces
   Resource* resource;

--- a/src/scheduler/CephSchedulerAgent.hpp
+++ b/src/scheduler/CephSchedulerAgent.hpp
@@ -387,7 +387,10 @@ string CephSchedulerAgent<T>::createExecutor(
     string configUriClientKeyring = prefix + "ceph.client.admin.keyring";
     string configUriCephConf = prefix + "ceph.conf";
     string configUriMonKeyring = prefix + "ceph.mon.keyring";
-    string configMonMap = prefix + "monmap";
+    string configUriMonMap = prefix + "monmap";
+    string configUriOSDKeyring = prefix + "ceph.keyring.osd";
+    string configUriRGWKeyring = prefix + "ceph.keyring.rgw";
+    string configUriMDSKeyring = prefix + "ceph.keyring.mds";
     uri = executor.mutable_command()->add_uris();
     uri->set_value(configUriClientKeyring);
     uri = executor.mutable_command()->add_uris();
@@ -395,7 +398,13 @@ string CephSchedulerAgent<T>::createExecutor(
     uri = executor.mutable_command()->add_uris();
     uri->set_value(configUriMonKeyring);
     uri = executor.mutable_command()->add_uris();
-    uri->set_value(configMonMap);
+    uri->set_value(configUriMonMap);
+    uri = executor.mutable_command()->add_uris();
+    uri->set_value(configUriOSDKeyring);
+    uri = executor.mutable_command()->add_uris();
+    uri->set_value(configUriRGWKeyring);
+    uri = executor.mutable_command()->add_uris();
+    uri->set_value(configUriMDSKeyring);
   }
   executor.mutable_command()->set_value(
       "./" + executorName);

--- a/src/scheduler/EventLoop.cpp
+++ b/src/scheduler/EventLoop.cpp
@@ -47,6 +47,7 @@ void EventLoop::recvData()
       if (flexUpMQ.try_receive(&event_data, sizeof(event_data), recvd_size, priority)){
           processData(string(event_data));
       }
+      usleep(3*1000000);
     }
   } catch (const std::exception& e){
     LOG(INFO) << "EventLoop.recvData " << e.what();

--- a/src/state/HostConfig.hpp
+++ b/src/state/HostConfig.hpp
@@ -41,6 +41,7 @@ public:
     originalConfig = get_config_by_hostname(hostname);
     pendingOSDDevs = originalConfig->osddevs;
     pendingJNLDevs = originalConfig->jnldevs;
+    jnlPartsCount = originalConfig->jnlparts;
   }
 
   HostConfig(Config* _config)
@@ -209,6 +210,11 @@ public:
     doneDiskPreparationFlag = true;
   }
 
+  int getJnlPartitionCount()
+  {
+    return jnlPartsCount;
+  }
+
 private:
 
   bool doneDiskPreparationFlag = false;
@@ -218,6 +224,8 @@ private:
   vector<string> pendingOSDDevs;
 
   vector<string> pendingJNLDevs;
+
+  int jnlPartsCount;
 
   vector<string> failedOSDDevs;
 


### PR DESCRIPTION
1. enable two networks using ceph/daemon.
2. using mgmtdev and datadev as CIDR (to be fixed later in ceph.conf merging module)
3. add jnlparts to let user control how many journal partitions to make on the jnldevs disks
4. temp "usleep" workaround for while(1) in httpserver