### PR TITLE
disambiguate unordered_map reference

### DIFF
--- a/src/state/StateMachine.hpp
+++ b/src/state/StateMachine.hpp
@@ -85,9 +85,9 @@ public:
   HostConfig* getConfig(string hostname);
 
 private:
-  unordered_map<std::string, ceph::TaskState> taskMap;
+  boost::unordered_map<std::string, ceph::TaskState> taskMap;
 
-  unordered_map<std::string, ceph::HostConfig> hostConfigMap;
+  boost::unordered_map<std::string, ceph::HostConfig> hostConfigMap;
 
   vector<int> pendingOSDID;
 


### PR DESCRIPTION
This was needed for me to build.

This is the Dockerfile I used to build the image:

```
FROM centos:7

RUN rpm -Uvh http://repos.mesosphere.io/el/7/noarch/RPMS/mesosphere-el-repo-7-1.noarch.rpm

RUN yum install -y epel-release \
 && yum groupinstall -y "Development Tools" \
 && yum install -y cmake mesos protobuf-devel boost-devel gflags-devel glog-devel yaml-cpp-devel  jsoncpp-devel libmicrohttpd-devel gmock-devel gtest-devel
```

