### PR TITLE
[Ready for review]  Resources object gets from Try<T> generic template.

### DIFF
--- a/src/scheduler/CephSchedulerAgent.hpp
+++ b/src/scheduler/CephSchedulerAgent.hpp
@@ -695,7 +695,9 @@ bool CephSchedulerAgent<T>::offerNotEnoughResources(const Offer& offer, TaskType
       "cpus:" + stringify(cpus) +
       ";mem:" + stringify(mems),config->role).get();
   Resources res = offer.resources();
-  if (res.flatten(config->role).contains(neededResources)) {
+  Resources resRole = res.flatten(config->role).get();
+  //if(res.contains(neededResources)){
+  if (resRole.contains(neededResources)) {
     return false;
   } else {
     return true;


### PR DESCRIPTION
 Changes to be committed:
	modified:   src/scheduler/CephSchedulerAgent.hpp
* Get Resources object from Try<Resources> generic template with  ```Try<Resources>::get()```.  ResRole object  get member function name ```Resources::contains()``` in order to check resource types.